### PR TITLE
Remove the need to import re

### DIFF
--- a/Module/WPSeku/modules/discovery/plugins/wplisting.py
+++ b/Module/WPSeku/modules/discovery/plugins/wplisting.py
@@ -35,7 +35,7 @@ class wplisting:
 			try:
 				url = self.check.checkurl(self.url,'wp-content/plugins/%s/%s'%(plugin,i))
 				resp = self.req.send(url)
-				if re.search('Index of',resp.read()):
+				if 'Index of' in resp.read():
 					self.printf.ipri('Listing: %s'%(url),color="g")
 			except Exception as error:
 				pass


### PR DESCRIPTION
The current code uses re.search() without importing re.  This change simplifies the search and removes th need to import re.